### PR TITLE
Strict mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ Please see the following table for some examples.
 |                                                     |     | /path/to/fixtures/example.com/api/comments.get.mock |
 |                                                     |     | /path/to/fixtures/example.com/api/comments.mock |
 
+### Strict mode
+The `ReponseBuilder` can be set to strict mode using `setStrictMode(true)`.
+When in strict mode, only the first possible fixture path will be used.
+This means that both the method and query params must be present in the fixture file name and it does not fall back to other fixture files.
+
 ### Helper
 <UrlHelper>Please see <a href="https://swisnl.github.io/php-http-fixture-client/#helper">https://swisnl.github.io/php-http-fixture-client/#helper</a> for the URL helper.</UrlHelper>
 

--- a/docs/.vuepress/components/UrlHelper.vue
+++ b/docs/.vuepress/components/UrlHelper.vue
@@ -15,6 +15,8 @@
             <option value="trace">TRACE</option>
             <option value="patch">PATCH</option>
         </select>
+        <h4>Strict mode</h4>
+        <label><input type="checkbox" v-model="strictMode"> Use strict mode</label>
         <h4>Possible fixtures (in order of specificity)</h4>
         <ol v-if="fixtures.length">
             <li v-for="fixture in fixtures">/path/to/fixtures/{{ fixture }}</li>
@@ -196,7 +198,8 @@
         data() {
             return {
                 url: '',
-                method: 'get'
+                method: 'get',
+                strictMode: false
             };
         },
 
@@ -222,6 +225,10 @@
 
                 fixtures.push(`${url.hostname}${pathname}.${this.method}.mock`);
                 fixtures.push(`${url.hostname}${pathname}.mock`);
+
+                if (this.strictMode) {
+                    fixtures = fixtures.slice(0, 1);
+                }
 
                 return fixtures;
             }

--- a/src/ResponseBuilder.php
+++ b/src/ResponseBuilder.php
@@ -41,6 +41,11 @@ class ResponseBuilder implements ResponseBuilderInterface
     private $responseFactory;
 
     /**
+     * @var bool
+     */
+    private $strictMode = false;
+
+    /**
      * @param string                             $fixturesPath
      * @param array                              $domainAliases
      * @param \Http\Message\ResponseFactory|null $responseFactory
@@ -50,6 +55,26 @@ class ResponseBuilder implements ResponseBuilderInterface
         $this->fixturesPath = $fixturesPath;
         $this->domainAliases = $domainAliases;
         $this->responseFactory = $responseFactory ?: MessageFactoryDiscovery::find();
+    }
+
+    /**
+     * @return bool
+     */
+    public function useStrictMode(): bool
+    {
+        return $this->strictMode;
+    }
+
+    /**
+     * @param bool $strictMode
+     *
+     * @return self
+     */
+    public function setStrictMode(bool $strictMode): self
+    {
+        $this->strictMode = $strictMode;
+
+        return $this;
     }
 
     /**
@@ -183,6 +208,10 @@ class ResponseBuilder implements ResponseBuilderInterface
 
         $possibleFiles[] = implode('.', [$basePathToFile, $method, $type]);
         $possibleFiles[] = implode('.', [$basePathToFile, $type]);
+
+        if ($this->useStrictMode()) {
+            $possibleFiles = array_slice($possibleFiles, 0, 1);
+        }
 
         return $possibleFiles;
     }

--- a/tests/ResponseBuilderTest.php
+++ b/tests/ResponseBuilderTest.php
@@ -65,6 +65,29 @@ class ResponseBuilderTest extends TestCase
     /**
      * @test
      */
+    public function it_can_be_set_to_strict_mode()
+    {
+        $builder = $this->getBuilder();
+
+        // Strict mode off
+        $this->assertFalse($builder->useStrictMode());
+
+        $messageFactory = MessageFactoryDiscovery::find();
+        $builder->build($messageFactory->createRequest('POST', 'http://example.com/api/articles?foo=bar'));
+
+        // Strict mode on
+        $builder->setStrictMode(true);
+        $this->assertTrue($builder->useStrictMode());
+
+        $this->expectException(MockNotFoundException::class);
+
+        $messageFactory = MessageFactoryDiscovery::find();
+        $builder->build($messageFactory->createRequest('POST', 'http://example.com/api/articles?foo=bar'));
+    }
+
+    /**
+     * @test
+     */
     public function it_throws_an_exception_when_it_cant_find_a_fixture()
     {
         $this->expectException(MockNotFoundException::class);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I added strict mode to the ResponseBuilder. When in strict mode, only the first possible fixture path will be used.

## Motivation and context

It can be useful to set the ResponseBuilder to strict mode. This makes the fixture resolution more explicit.

## How has this been tested?

Tested using existing unit tests for PHP. Docs don't have tests.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
